### PR TITLE
feature: Run isolate when create MultipartFileRecreatable object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+.fvm

--- a/lib/src/multipart_file_recreatable.dart
+++ b/lib/src/multipart_file_recreatable.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 import 'package:dio/dio.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as p;
@@ -32,6 +33,19 @@ class MultipartFileRecreatable extends MultipartFile {
       contentType: contentType,
     );
   }
+
+  static Future<MultipartFileRecreatable> fromFileIsolate(
+    String filePath, {
+    String? filename,
+    MediaType? contentType,
+  }) =>
+      Isolate.run(
+        () => fromFileSync(
+          filePath,
+          filename: filename,
+          contentType: contentType,
+        ),
+      );
 
   MultipartFileRecreatable recreate() => fromFileSync(
         filePath,

--- a/test/multipart_retry_tests.dart
+++ b/test/multipart_retry_tests.dart
@@ -59,4 +59,48 @@ void main() {
 
     expect(evaluator.currentAttempt, retries);
   });
+
+  test('Create MultipartFileRecreatable with Isolate', () async {
+    try {
+      final multiPartFile =
+          await MultipartFileRecreatable.fromFileIsolate('README.md');
+      expect(multiPartFile, isA<MultipartFileRecreatable>());
+    } catch (e) {
+      fail('Failure Test');
+    }
+  });
+
+  test('Retry for MultipartFileRecreatable is retrying with isolate', () async {
+    final dio = Dio();
+    const retries = 2;
+    final evaluator = DefaultRetryEvaluator(defaultRetryableStatuses);
+    dio.interceptors.add(
+      RetryInterceptor(
+        dio: dio,
+        logPrint: print,
+        retries: retries,
+        retryDelays: const [Duration(seconds: 1), Duration(seconds: 1)],
+        retryEvaluator: evaluator.evaluate,
+      ),
+    );
+
+    try {
+      final multiPartFile = await MultipartFileRecreatable.fromFileIsolate(
+        'README.md',
+      );
+      final formData = FormData.fromMap({
+        'file': multiPartFile,
+      });
+      await dio.post<dynamic>(
+        'https://rodion-m.ru/mock/post500.php',
+        data: formData,
+      );
+    } on DioError catch (e) {
+      if (e.type != DioErrorType.badResponse) {
+        rethrow;
+      }
+    }
+
+    expect(evaluator.currentAttempt, retries);
+  });
 }


### PR DESCRIPTION
hi @rodion-m 
we know when the object tries to recreate MultipartFileRecreatable object, will run on the main Isolate memory,

https://github.com/rodion-m/dio_smart_retry/blob/ce295aaea62f8c0e246200f869f9bf2b92d75637/lib/src/retry_interceptor.dart#L181

which is, when the apps try to retry and have Multipart of files, the apps will get decreased performance(jank UI), So I'm trying to change the object recreated from running(sync) in the main isolate, to different memory(Concurrency with Isolate).

what do u think?

I'm sorry if my English is so bad. Thank you.
