### PR TITLE
fixes #34

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />


### PR DESCRIPTION
In this PR, I fixed the issue where developers can't access the index of the retry attempt, I noticed that there was already a way to do so but the attempt number always had the same value which was the number of attempts, I added the number to the DioException object and now the developer can access the index but in reverse order, for example if the implementation had 3 attempts then the dev will see the following attempt indices:
3, 3, 2, 1

The firs number is for the original call that failed (done by the user), and the rest are the retries, the developer can access the index from extras inside the request options by using the key that I made public

Example:
```
InterceptorsWrapper interceptor = InterceptorsWrapper(
  onError: (error, handler) {
    if (error.requestOptions.extra[dioSmartRetryAttemptKey] == 1) {
      // one time action
    }

    handler.next(error);
  },
);
```