### PR TITLE
Use the value of the Retry-After header when present

### DIFF
--- a/lib/src/retry_interceptor.dart
+++ b/lib/src/retry_interceptor.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/src/default_retry_evaluator.dart';
@@ -115,7 +116,7 @@ class RetryInterceptor extends Interceptor {
     }
 
     err.requestOptions._attempt = attempt;
-    final delay = _getDelay(attempt);
+    final delay = _getDelay(attempt, err);
     logPrint?.call(
       '[${err.requestOptions.path}] An error occurred during request, '
       'trying again '
@@ -146,7 +147,31 @@ class RetryInterceptor extends Interceptor {
     }
   }
 
-  Duration _getDelay(int attempt) {
+  Duration _getDelay(int attempt, DioException? err) {
+    final retryAfter = err?.response?.headers.value('retry-after');
+    
+    if (retryAfter != null) {
+      // Try parsing as seconds first
+      final seconds = int.tryParse(retryAfter);
+      if (seconds != null && seconds >= 0) {
+        return Duration(seconds: seconds);
+      }
+      
+      // Try parsing as HTTP date
+      try {
+        final date = HttpDate.parse(retryAfter);
+        final now = DateTime.now().toUtc();
+        final wait = date.difference(now);
+        if (wait.isNegative) {
+          return Duration.zero;
+        }
+        return wait;
+      } catch (_) {
+        // Invalid date format, fall through to default delay
+      }
+    }
+
+    // Fall back to configured delays if no valid Retry-After
     if (retryDelays.isEmpty) return Duration.zero;
     return attempt - 1 < retryDelays.length
         ? retryDelays[attempt - 1]

--- a/lib/src/retry_interceptor.dart
+++ b/lib/src/retry_interceptor.dart
@@ -149,14 +149,14 @@ class RetryInterceptor extends Interceptor {
 
   Duration _getDelay(int attempt, DioException? err) {
     final retryAfter = err?.response?.headers.value('retry-after');
-    
+
     if (retryAfter != null) {
       // Try parsing as seconds first
       final seconds = int.tryParse(retryAfter);
       if (seconds != null && seconds >= 0) {
         return Duration(seconds: seconds);
       }
-      
+
       // Try parsing as HTTP date
       try {
         final date = HttpDate.parse(retryAfter);

--- a/test/retry_after_test.dart
+++ b/test/retry_after_test.dart
@@ -22,8 +22,7 @@ void main() {
         dio: dio,
         retries: 1,
         logPrint: print,
-        //This should be ignored for Retry-After
-        retryDelays: const [Duration(seconds: 30)],
+        retryDelays: const [Duration(seconds: 1)],
       );
       dio.interceptors.add(interceptor);
     });
@@ -56,6 +55,23 @@ void main() {
       }
       final duration = DateTime.now().difference(startTime);
       expect(duration.inSeconds, lessThanOrEqualTo(2));
+      expect(exceptionThrown, true);
+    });
+
+    test('invalid Retry-After header is ignored', () async {
+      final startTime = DateTime.now();
+      var exceptionThrown = false;
+
+      final futureDate = DateTime.now().toUtc().add(const Duration(seconds: 2));
+      final httpDate = HttpDate.format(futureDate);
+
+      try {
+        await dio.get<dynamic>('$retryAfter429Date/invalid-date');
+      } catch (_) {
+        exceptionThrown = true;
+      }
+      final duration = DateTime.now().difference(startTime);
+      expect(duration.inSeconds, greaterThanOrEqualTo(1));
       expect(exceptionThrown, true);
     });
   });

--- a/test/retry_after_test.dart
+++ b/test/retry_after_test.dart
@@ -1,0 +1,62 @@
+@TestOn('vm')
+library;
+
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const retryAfter429Seconds = 'https://httpbun.com/mix/s=429/h=retry-after:2';
+  const retryAfter429Date = 'https://httpbun.com/mix/s=429/h=retry-after:';
+
+  group('Retry-After header handling', () {
+    late Dio dio;
+    late RetryInterceptor interceptor;
+
+    setUp(() {
+      dio = Dio();
+      interceptor = RetryInterceptor(
+        dio: dio,
+        retries: 1,
+        logPrint: print,
+        //This should be ignored for Retry-After
+        retryDelays: const [Duration(seconds: 30)],
+      );
+      dio.interceptors.add(interceptor);
+    });
+
+    test('respects Retry-After with seconds format for 429', () async {
+      final startTime = DateTime.now();
+      var exceptionThrown = false;
+
+      try {
+        await dio.get<dynamic>(retryAfter429Seconds);
+      } catch (_) {
+        exceptionThrown = true;
+      }
+      final duration = DateTime.now().difference(startTime);
+      expect(duration.inSeconds, greaterThanOrEqualTo(2));
+      expect(exceptionThrown, true);
+    });
+
+    test('respects Retry-After with date format for 429', () async {
+      final startTime = DateTime.now();
+      var exceptionThrown = false;
+
+      final futureDate = DateTime.now().toUtc().add(const Duration(seconds: 2));
+      final httpDate = HttpDate.format(futureDate);
+
+      try {
+        await dio.get<dynamic>('$retryAfter429Date$httpDate');
+      } catch (_) {
+        exceptionThrown = true;
+      }
+      final duration = DateTime.now().difference(startTime);
+      expect(duration.inSeconds, lessThanOrEqualTo(2));
+      expect(exceptionThrown, true);
+    });
+  });
+}

--- a/test/retry_after_test.dart
+++ b/test/retry_after_test.dart
@@ -62,9 +62,6 @@ void main() {
       final startTime = DateTime.now();
       var exceptionThrown = false;
 
-      final futureDate = DateTime.now().toUtc().add(const Duration(seconds: 2));
-      final httpDate = HttpDate.format(futureDate);
-
       try {
         await dio.get<dynamic>('$retryAfter429Date/invalid-date');
       } catch (_) {

--- a/test/retry_after_test.dart
+++ b/test/retry_after_test.dart
@@ -1,7 +1,6 @@
 @TestOn('vm')
 library;
 
-
 import 'dart:io';
 
 import 'package:dio/dio.dart';


### PR DESCRIPTION
This PR modifies _getDelay to be passed the DioException and looks for the retry-after header in the response. When its present it attempts to parse it into seconds or an HTTP Date as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After If the header is not present or the header is malformed it falls back to the Duration based on the attempt.

I added test coverage as well using httpbun.com to respond with a 429 and different values of retry-after headers.
I believe this should be backwards compatible.